### PR TITLE
speed up flash backups and restores by a factor of 5-10

### DIFF
--- a/utilities/mtd-backup
+++ b/utilities/mtd-backup
@@ -86,12 +86,12 @@ then
   if [ $CRON_ACTION = remove ]
   then
     sed -e "/$SCRIPT/d" -i /etc/crontabs/root
-    echo Scheduled backup has been removed. 
+    echo Scheduled backup has been removed.
   else
     mm=$(awk 'BEGIN{srand();print int(rand()*59);}')
     hh=$(awk 'BEGIN{srand();print int(rand()*3)+2;}')
     echo "$mm $hh * * * $(cd $(dirname $0); pwd)/$SCRIPT -c -e -o -y" >> /etc/crontabs/root
-    echo Backup has been scheduled to execute at $hh:${mm}am every day. 
+    echo Backup has been scheduled to execute at $hh:${mm}am every day.
     echo Execution messages will be written to the system log, and can be viewed with the following command:
     echo
     echo "  logread -e mtd-backup"
@@ -123,7 +123,7 @@ fi
 
 if [ $DUMP_CFG = Y ]
 then
-  $LOGGER user.info WRITING current configuration to /mnt/usb/$USB/backups/$VARIANT-$SERIAL-config.gz 
+  $LOGGER user.info WRITING current configuration to /mnt/usb/$USB/backups/$VARIANT-$SERIAL-config.gz
   SECONDS=$(date +%s)
   uci show 2>/dev/null | grep -v -E '^env' | gzip > /mnt/usb/$USB/backups/$VARIANT-$SERIAL-config.gz
   if [ $DEBUG = Y ]
@@ -173,7 +173,7 @@ sed -e '/dev:/d' -e 's/\(mtd.\)[^"]*"\([^"]*\)"/\1 \2/' /proc/mtd | while read -
 do
   if [ -f /mnt/usb/$USB/backups/$VARIANT-$dev-$name.img.sha256 ]
   then
-    SHA256OLD="$(cat /mnt/usb/$USB/backups/$VARIANT-$dev-$name.img.sha256)"
+    SHA256OLD="$(cat /mnt/usb/$USB/backups/$VARIANT-$dev-$name.img.sha256 | cut -d' ' -f1)"
   else
     SHA256OLD=""
   fi
@@ -182,7 +182,7 @@ do
     $LOGGER user.debug Calculating SHA256 for $name..
     SECONDS=$(date +%s)
   fi
-  SHA256=$(dd if=/dev/$dev 2>/dev/null | sha256sum)
+  SHA256=$(sha256sum "/dev/${dev}ro" | cut -d' ' -f1)
   if [ $DEBUG = Y ]
   then
     $LOGGER user.debug Calculating SHA256 for $name took $(( $(date +%s) - $SECONDS )) seconds
@@ -194,7 +194,7 @@ do
   else
     $LOGGER user.info WRITING $name to /mnt/usb/$USB/backups/$VARIANT-$dev-$name.img.gz
     SECONDS=$(date +%s)
-    dd if=/dev/$dev | gzip > /mnt/usb/$USB/backups/$VARIANT-$dev-$name.img.gz
+    dd if="/dev/${dev}ro" bs=1M | gzip > /mnt/usb/$USB/backups/$VARIANT-$dev-$name.img.gz
     if [ $DEBUG = Y ]
     then
       $LOGGER user.debug WRITING $name to /mnt/usb/$USB/backups/$VARIANT-$dev-$name.img.gz took $(( $(date +%s) - $SECONDS )) seconds

--- a/utilities/mtd-restore
+++ b/utilities/mtd-restore
@@ -48,7 +48,7 @@ do
   do
     if [ -f /mnt/usb/$USB/backups/$VARIANT-$dev-$name.img.sha256 ]
     then
-      SHA256OLD="$(cat /mnt/usb/$USB/backups/$VARIANT-$dev-$name.img.sha256)"
+      SHA256OLD="$(cat /mnt/usb/$USB/backups/$VARIANT-$dev-$name.img.sha256 | cut -d' ' -f1)"
     else
       echo $(date +%F@%X): SKIPPED restore of $gz: $VARIANT-$dev-$name.img.sha256 does not exist?
       continue
@@ -56,7 +56,7 @@ do
     if [ -z "$1" ]
     then
       echo $(date +%F@%X): CALCULATING current SHA256 checksum for $name
-      SHA256=$(dd if=/dev/$dev 2>/dev/null | sha256sum)
+      SHA256=$(sha256sum "/dev/${dev}ro" | cut -d' ' -f1)
     else
       echo $(date +%F@%X): SKIPPED calculation of current SHA256 checksum for $name because requested restore of $1
       SHA256=""


### PR DESCRIPTION
Made a few small tweaks to the `mtd-backup` and `mtd-restore` scripts to _massively_ reduce how long they take to run

Using just `/dev/mtd0` as a reference, before:

```
mtd-backup: Calculating SHA256 for brcmnand.0..
mtd-backup: Calculating SHA256 for brcmnand.0 took 370 seconds
mtd-backup: WRITING brcmnand.0 to /mnt/usb/USB-A1/backups/DJA0231-mtd0-brcmnand.0.img.gz
mtd-backup: WRITING brcmnand.0 to /mnt/usb/USB-A1/backups/DJA0231-mtd0-brcmnand.0.img.gz took 436 seconds
mtd-backup: WRITING checksum to /mnt/usb/USB-A1/backups/DJA0231-mtd0-brcmnand.0.img.sha256
```

After:

```
mtd-backup: Calculating SHA256 for brcmnand.0..
mtd-backup: Calculating SHA256 for brcmnand.0 took 76 seconds
mtd-backup: WRITING brcmnand.0 to /mnt/usb/USB-A1/backups/DJA0231-mtd0-brcmnand.0.img.gz
mtd-backup: WRITING brcmnand.0 to /mnt/usb/USB-A1/backups/DJA0231-mtd0-brcmnand.0.img.gz took 102 seconds
mtd-backup: WRITING checksum to /mnt/usb/USB-A1/backups/DJA0231-mtd0-brcmnand.0.img.sha256
```

Full backup time after changes:
```
mtd-backup: Backup completed in 370 seconds
```
which is the same amount of time as just that one checksum operation used to take!

Actual changes made:

- Switched to reading from `/dev/mtd*ro` device instead of `/dev/mtd*` in backup/checksum to prevent any chance of writing during these processes
- Changed checksum to use direct sha256sum execution on the device file path, passing output through `cut` to trim the file path off the end before saving
- Added `bs=1M` option to `dd` read command; by default `dd` reads either 512B or 4KB at a time which takes up an enormous amount of CPU time on context switches, 1MB blocks work fine on devices with this much RAM and are an order of magnitude faster
- Added `cut` to the checksum file readback so existing `.sha256sum` files will still verify correctly

no major changes and shouldn't break compatibility with existing checksum files, it'll just be a lot faster.
