### PR TITLE
Fix backend DMZ validation

### DIFF
--- a/build/common/190-Fix-post_helper
+++ b/build/common/190-Fix-post_helper
@@ -75,15 +75,15 @@ function M.validateDMZ(value, object)\
   }\
   if object.DMZ_enable == "1" then\
     content_helper.getExactContent(network)\
-    local isDestIP, errormsg = post_helper.getValidateStringIsDeviceIPv4(network.gateway_ip, network.netmask)(value)\
+    local isDestIP, errormsg = M.getValidateStringIsDeviceIPv4(network.gateway_ip, network.netmask)(value)\
     if not isDestIP then\
       return nil, errormsg\
     end\
-    isDestIP, errormsg = post_helper.reservedIPValidation(value)\
+    isDestIP, errormsg = M.reservedIPValidation(value)\
     if not isDestIP then\
       return nil, errormsg\
     end\
-    isDestIP, errormsg = post_helper.validateQTN(value)\
+    isDestIP, errormsg = M.validateQTN(value)\
     if not isDestIP then\
       return nil, errormsg\
     end\


### PR DESCRIPTION
Hi there,

First and foremost -- fantastic project, thank you so much for putting this together. I've been using it and it's been great on my DJN2130.

This PR will fix a DMZ validation bug. Without it, you cannot set a DMZ via the frontend (you won't get any error message but the backend will give an error status code).

In the Lua logs, the following will be displayed:

```
[error] 4074#0: *117 lua entry thread aborted: runtime error: /usr/lib/lua/web/post_helper.lua:1886: attempt to index global 'post_helper' (a nil value)
stack traceback:
coroutine 0:
	/usr/lib/lua/web/post_helper.lua:1886: in function '?'
	/usr/lib/lua/web/content_helper.lua:539: in function 'validateObject'
	/usr/lib/lua/web/post_helper.lua:89: in function 'handleQuery'
	[string "/modals/wanservices-modal.lp"]:199: in function 'content'
	/usr/lib/lua/web/web.lua:249: in function 'process'
	content_by_lua(nginx.conf:99):4: in function <content_by_lua(nginx.conf:99):1>
```

Looking through the code I noticed that all the `post_helper` was renamed to `M` so I took that approach and it seemed to have fixed the issue.